### PR TITLE
Added support for json5 files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,44 @@ testmachinepack
 
 ## Writing tests
 
-So what do the tests look like?
+Tests will be written in JSON or [JSON5](http://json5.org/) format (with .json5 file ending). For each machine you have define you create a JSON file with the same name within a `tests` folder. If you install [machinepack](https://github.com/node-machine/machinepack) and run `pm scrub` skeleton files will be created for you.
+
+The general format looks like this:
+
+```js
+//machine-name.json, or machine-name.json5 if you want comment support
+{
+  //name of the machine as per filename
+  "machine": "machine-name",
+  //within expectations you define the tests of your machine
+  //based on the inputs and exits you have defined
+  "expectations": [
+    {
+      //todo truthy means the test will be skipped
+      "todo": true,
+      "using": {
+        "variable1": ""
+      },
+      "outcome": ""
+    },
+    {
+      "using": {
+        "variable1": "value"
+      },
+      "outcome": "error"
+    },
+    {
+      "using": {
+        "variable": "value1",
+        "variable2": "value2"
+      },
+      "outcome": "error"
+    }
+  ]
+}
+```
+
+So what do real tests look like?
 Check out this example from [machinepack-npm](http://node-machine.org/machinepack-npm):
 https://github.com/mikermcneil/machinepack-npm/blob/master/tests/list-packages.json
 

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
     "testmachinepack": "./bin/testmachinepack.js"
   },
   "dependencies": {
-    "lodash": "^3.1.0",
-    "async": "^0.9.0"
+    "async": "^0.9.0",
+    "json5": "^0.4.0",
+    "lodash": "^3.1.0"
   },
   "repository": {
     "type": "git",

--- a/run-all-tests.js
+++ b/run-all-tests.js
@@ -6,6 +6,8 @@ var util = require('util');
 var _ = require('lodash');
 var async = require('async');
 var path = require('path');
+//replace's nodejs' require to support requiring of .json5 files
+require('json5/lib/require');
 
 
 module.exports = function (mpPath, beforeRunningAnyTests, eachTestSuite, done){
@@ -36,9 +38,14 @@ module.exports = function (mpPath, beforeRunningAnyTests, eachTestSuite, done){
 
       eachTestSuite(machineIdentity, function (onTestFn, informSuiteFinished){
 
-        // Load machine tests
-        var pathToTestSuiteModule = path.resolve(testsPath, machineIdentity + '.json');
-        var testSuite = require(pathToTestSuiteModule);
+        // Load machine tests, supporting .json and .json5 files
+        var pathToTestSuiteModule = path.resolve(testsPath, machineIdentity);
+        var testSuite;
+        try {
+          testSuite = require(pathToTestSuiteModule + '.json');
+        } catch (e) {
+          testSuite = require(pathToTestSuiteModule + '.json5');
+        }
 
         // And run them
         require('./run-test-suite')(

--- a/run-all-tests.js
+++ b/run-all-tests.js
@@ -44,6 +44,9 @@ module.exports = function (mpPath, beforeRunningAnyTests, eachTestSuite, done){
         try {
           testSuite = require(pathToTestSuiteModule + '.json');
         } catch (e) {
+          if (e.toString().indexOf('SyntaxError') > -1) {
+            throw e;
+          }
           testSuite = require(pathToTestSuiteModule + '.json5');
         }
 


### PR DESCRIPTION
As mentioned in https://github.com/node-machine/test-machinepack/issues/1

This now looks for `.json` files first and if it does not find them, for `.json5`.
Is useful to comment out multiple tests temporarily using text-editor hotkeys or add comments to specific tests and in general just makes json nicer to write for humans.

Edit: This has been tested in my local repository.

Edit2: Also extended the readme a bit.
