### PR TITLE
Added `undefined` value handling

### DIFF
--- a/run-test-suite.js
+++ b/run-test-suite.js
@@ -168,7 +168,7 @@ module.exports = function (Pack, testSuite, eachTest, done){
 
               // If output assertion is a string, but the machine is expecting JSON
               // then attempt to parse the output assertion before performing the check.
-              var isExpectingJson = (typeSchema !== 'string' && typeSchema !== 'number' && typeSchema !== 'boolean' && typeSchema !== 'lamda');
+              var isExpectingJson = (typeSchema !== 'string' && typeSchema !== 'number' && typeSchema !== 'boolean' && typeSchema !== 'lamda' && typeSchema !== 'ref');
               if (_.isString(outputAssertion) && isExpectingJson) {
                 try {
                   outputAssertion = JSON.parse(outputAssertion);


### PR DESCRIPTION
Related to the https://github.com/sailshq/machinepack-process/pull/6, I found that `example` is not supposed to be `undefined` value in `run-test-suite.js`. So, I added `undefined` value (in the case, `typeschema` was `ref`) handling in `run-test-suite.js`.