### PR TITLE
Use the right attribute of exitDef for the example

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "test-machinepack",
   "author": "Mike McNeil <@mikermcneil>",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Raw test runner for machinepacks (also includes a simple stub test driver)",
   "keywords": [
     "test-machine",

--- a/run-test-suite.js
+++ b/run-test-suite.js
@@ -159,7 +159,7 @@ module.exports = function (Pack, testSuite, eachTest, done){
           // between pieces, and for use in decoding the expected output below.
           var typeSchema;
           try {
-            typeSchema = rttc.infer(exitDef.example);
+            typeSchema = rttc.infer(exitDef.outputExample);
 
             // If it's present, now hydrate the `outputAssertion` for this test
             // (the expected return value) in case it contains any stringified lamda functios

--- a/test-machine.js
+++ b/test-machine.js
@@ -247,11 +247,11 @@ module.exports = require('machine').build({
             var exitDef = machineInstance.exits[whatActuallyHappened.outcome];
             // and use it to infer the expected `typeSchema` in order to do a
             // better comparison with isEqual().
-            if (_.isUndefined(exitDef.example)) {
+            if (_.isUndefined(exitDef.outputExample)) {
               failureReport.wrongOutput = !rttc.isEqual(outputAssertion, whatActuallyHappened.output);
             }
             else {
-              var typeSchema = rttc.infer(exitDef.example);
+              var typeSchema = rttc.infer(exitDef.outputExample);
               failureReport.wrongOutput = !rttc.isEqual(outputAssertion, whatActuallyHappened.output, typeSchema);
             }
           }


### PR DESCRIPTION
See commit 3bc3a4da982ab6ef9cfb9d308198c2a9b7fb9f13 which changed the field
from `example` to `outputExample`.